### PR TITLE
Fix DTR pin not set as an output

### DIFF
--- a/esptool-ftdi.py
+++ b/esptool-ftdi.py
@@ -160,7 +160,7 @@ class serial_via_libftdi(object):
 
         # Bitbang mode
         if not self.bitmode:
-            self.ftdi_fn.ftdi_set_bitmode(0x0d, 0x01)
+            self.ftdi_fn.ftdi_set_bitmode(0x1d, 0x01)
         self.bitmode = True
         self.write("%c" % val)
 

--- a/esptool-ftdi.py
+++ b/esptool-ftdi.py
@@ -160,6 +160,10 @@ class serial_via_libftdi(object):
 
         # Bitbang mode
         if not self.bitmode:
+            # set bitmode using the bitmask and mode (0x01 = bit-banging)
+            # the bitmask is referencing the pins as follows ( https://ftdichip.com/wp-content/uploads/2020/07/AN_184-FTDI-Device-Input-Output-Pin-States.pdf table 5.3) :
+            # 7    6   5   4   3   2   1   0
+            # RI  DCD DSR DTR CTS RTS RXD TXD
             self.ftdi_fn.ftdi_set_bitmode(0x1d, 0x01)
         self.bitmode = True
         self.write("%c" % val)


### PR DESCRIPTION
Because i couldn't find documentation on how to set the bitmask easily, i've now added it, and it should fix the unclear PR that i made before https://github.com/jimparis/esptool-ftdi/pull/8 .

If you want to use a cheap FTDI-board like the ones found on amazon 
![image](https://user-images.githubusercontent.com/90630/194593913-741c0081-999d-477e-9e1f-918b4d13dfa3.png)
to program your ESP32, you'll need the cts-dtr branch. This PR fixes the issue that the DTR doesn't actually toggle when using that branch. 