### PR TITLE
Add name field to the class

### DIFF
--- a/esptool-ftdi.py
+++ b/esptool-ftdi.py
@@ -111,6 +111,7 @@ class serial_via_libftdi(object):
         self._ftdi_close()
 
     def __init__(self, port):
+        self.name = "rfc2217:esptool-ftdi"
         self.port = port
         self._baudrate = 9600
         self._timeout = 5.0


### PR DESCRIPTION
Since esptool v4.5 the name field is evaluated by the ESPLoader class in loader.py to construct a reset strategy. If this name starts with "rfc2217:" the behavior is as earlier. Otherwise the reset is attempted using direct fcntl access to the underlying serial port via the fileno() function (which is currently not implemented by esptool-ftdi.py). Keeping full control over the serial port from within esptool-ftdi.py seems the much better option so make sure the name starts with "rfc2217:".